### PR TITLE
Add fetch proxy interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,13 +14,23 @@ import {
   UpdateParams,
   UpdateResult,
 } from "ra-core";
-import { OData, param, EdmV4, ODataQueryParam } from "@odata/client";
+import { OData, param, EdmV4, ODataQueryParam, ODataNewOptions, FetchProxy } from "@odata/client";
 import { resource_id_mapper } from "./ra-data-id-mapper";
 import { parse_metadata } from "./metadata_parser";
 
-async function get_entities(url: string, options: ODataRequestOptions) {
-  const m = await fetch(url + "/$metadata", options);
-  const t = await m.text();
+async function get_entities(url: string, fetchProxy?: FetchProxy) {
+  let t: string;
+  url += "/$metadata";
+
+  if (fetchProxy)
+    // content needs to be a string in order to be correctly passed to parse_metadata
+    // TODO: document this
+    // TODO: test case
+    t = (await fetchProxy(url, {})).content;
+  else {
+    const m = await fetch(url);
+    t = await m.text();
+  }
 
   return parse_metadata(t);
 }
@@ -36,16 +46,13 @@ export type OdataDataProvider = DataProvider<string> & {
   action: (resource: string, params: ActionParams) => Promise<any>;
 };
 
-interface ODataRequestOptions {
-  headers?: Record<string, string>;
-}
-
 const ra_data_odata_server = async (
   apiUrl: string,
-  option_callback: () => Promise<ODataRequestOptions> = () =>
+  odata_options_callback: () => Promise<Partial<ODataNewOptions>> = () =>
     Promise.resolve({})
 ): Promise<OdataDataProvider> => {
-  const resources = await get_entities(apiUrl, await option_callback());
+  const options = await odata_options_callback();
+  const resources = await get_entities(apiUrl, options.fetchProxy);
   const id_map: Record<string, string> = {};
   for (const r in resources) {
     const id_name = resources[r]?.Key?.Name ?? "id";
@@ -81,10 +88,10 @@ const ra_data_odata_server = async (
   }
 
   const getClient = async () => {
-    const commonHeaders = (await option_callback()).headers;
+    const options = (await odata_options_callback());
     const client = OData.New4({
       metadataUri: apiUrl + "/$metadata",
-      commonHeaders,
+      ...options,
     });
     return client;
   };

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -257,7 +257,7 @@ test("Custom fetch proxy", async () => {
         method: init.method,
         credentials: 'include',
         headers: {
-          'Content-Type': 'application/json',
+          'Content-Type': 'text/plain',
           'X-Some-Custom': 'Header',
         },
       });
@@ -291,6 +291,11 @@ test("Custom fetch proxy", async () => {
     Northwind + "/Categories?$orderby=CategoryID asc&$top=15&$count=true"
   );
   expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+  expect(fetchMock.mock.calls[1][1]?.credentials).toEqual('include');
+  expect(fetchMock.mock.calls[1][1]?.headers).toEqual({
+    'Content-Type': 'text/plain',
+    'X-Some-Custom': 'Header',
+  });
   expect(data[0]).toMatchObject({
     id: 1,
     CategoryName: "Beverages",

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -1,6 +1,7 @@
 import fs from "fs";
 import odataProvider from "./index";
 import { enableFetchMocks } from "jest-fetch-mock";
+import { ODataNewOptions } from "@odata/client";
 enableFetchMocks();
 
 const Northwind = "https://services.odata.org/v4/Northwind/Northwind.svc";
@@ -182,7 +183,7 @@ test("Get many referenced Products from Northwind", async () => {
   });
   expect(fetchMock.mock.calls[1][0]).toEqual(
     Northwind +
-      "/Products?$filter=CategoryID eq 1&$orderby=ProductName asc&$top=10&$count=true"
+    "/Products?$filter=CategoryID eq 1&$orderby=ProductName asc&$top=10&$count=true"
   );
 });
 
@@ -247,4 +248,52 @@ test("Actions creates a POST request", async () => {
   expect(fetchMock.mock.calls[1][1]?.method).toEqual("POST");
   const body = fetchMock.mock.calls[1][1]?.body?.toString() ?? "";
   expect(JSON.parse(body)).toEqual({ miles: 100 });
+});
+
+test("Custom fetch proxy", async () => {
+  const customOptions = async (): Promise<Partial<ODataNewOptions>> => ({
+    fetchProxy: async (url, init) => {
+      const response = await fetch(url, {
+        method: init.method,
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Some-Custom': 'Header',
+        },
+      });
+
+      let content: any;
+      if (url.endsWith("/$metadata"))
+        // metadata needs to be parsed as text
+        content = await response.text();
+      else
+        // all other content needs to be parsed as json
+        content = await response.json();
+
+      return {
+        response,
+        content,
+      };
+    },
+  })
+
+  const provider = await odataProvider(Northwind, customOptions);
+  fetchMock.mockOnce(
+    fs.readFileSync("./test/service/Categories.json").toString(),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  const { data } = await provider.getList("Categories", {
+    pagination: { page: 1, perPage: 15 },
+    sort: { field: "CategoryID", order: "asc" },
+    filter: null,
+  });
+  expect(fetchMock.mock.calls[1][0]).toEqual(
+    Northwind + "/Categories?$orderby=CategoryID asc&$top=15&$count=true"
+  );
+  expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+  expect(data[0]).toMatchObject({
+    id: 1,
+    CategoryName: "Beverages",
+    Description: "Soft drinks, coffees, teas, beers, and ales",
+  });
 });


### PR DESCRIPTION
Hi John,

here is my first proposal for the fetch proxy implementation. It still needs some documentation (metadata-request needs to return a string, whereas all other (content) requests need to be returned as json) and possibly some test cases.

I avoided the type hell by just shifting the responsibility to the user of the library. He/she needs to deal with types around the custom fetch implementation, so the library should not be affected by any type issues. Basically I just re-used what @odata/client exposes as `ODataNewOptions`. This way the user is free to configure everything that's provided by @odata/client.

Any thoughts, criticism, improvements appreciated!