### PR TITLE
fix promise handling in deleteMany

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -322,9 +322,9 @@ const ra_data_odata_server = async (
         const client = await getClient();
         const es = client.getEntitySet<RecordType>(resource);
 
-        const results = params.ids.map((id) => {
-          es.delete(getproperty_identifier(resource, keyName, id));
-        });
+        const results = params.ids.map((id) => 
+          es.delete(getproperty_identifier(resource, keyName, id))
+        );
 
         await Promise.all(results);
 


### PR DESCRIPTION
Hi @jvert,

I've discovered a potential misbehaviour of the deleteMany functionality. Currently all executed http calls are awaited by a `Promise.all(...)`, however, as no `return` is used, the resulting `results` array is of type `void[]` rather than of type `Promise[]`. The result is that the call to `Promise.all(...)` is not working as intended, as the array will never contain any promises. The PR fixes this behaviour.

Cheers!