### PR TITLE
Add support all react-admin filter operators

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ra-data-odata-server",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ra-data-odata-server",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "MIT",
       "dependencies": {
         "@odata/client": "^2.21.6",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc -p tsconfig.build.json",
     "test": "jest"
   },
   "keywords": [

--- a/readme.md
+++ b/readme.md
@@ -99,6 +99,26 @@ Multiple filters can also be combined and used directly with the [`<List>`](http
 </List>
 ```
 
+### List Sorting
+
+The name of the field to be sorted is converted to a format that OData understands. For example, "category.name" will turn into "Category/Name".
+
+```ts
+<List resource="posts"
+    filter={{
+      author_eq: "John Smith",
+      published_at_gte: "2020-01-01T23:59:59.99Z"
+    }}>
+    <Datagrid rowClick="show">
+      <TextField source="id" />
+      <TextField source="title" />
+      <DateField source="published_at" />
+      <TextField source="category" sortBy="category.name" />
+      <BooleanField source="commentable" />
+    </Datagrid>
+</List>
+```
+
 ### OData Actions
 
 This provider has built-in support for invoking OData actions. This works with react-admin's

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,19 @@ _lte| le | `filter: {price_lte: 0.99}`
 _lt| lt | `filter: {price_lt: 1}`
 _gte| ge | `filter: {price_gte: 1}`
 _gt| gt | `filter: {quantity_gt: 10}`
+_eq_any| in | `filter: {quantity_eq_any: [10, 20]}`
+_neq_any| not in | `filter: {quantity_neq_any: [10, 20]}`
+_inc| eq (AND) | `filter: {quantity_inc: [10, 20]}`
+_inc_any| eq (OR) | `filter: {quantity_inc_any: [10, 20]}`
+_ninc_any| ne (AND) | `filter: {quantity_ninc_any: [10, 20]}`
+_boolean| eq | `filter: {active_boolean: true}`
+_q| contains | `filter: {name_q: "John"}`
+
+If the filter field name is `q`, then it is converted to a search query:
+
+```
+filter: {q: "John"} -> $search=John
+```
 
 If a suffix operator is not supplied, then the default filter operator is `Contains` to search a field for a substring.
 

--- a/readme.md
+++ b/readme.md
@@ -119,6 +119,54 @@ The name of the field to be sorted is converted to a format that OData understan
 </List>
 ```
 
+### Select fields
+
+If the API provides more data than necessary, then you can request only those fields that are needed.
+
+```ts
+<ReferenceInput
+  source="user.id"
+  reference="users"
+  queryOptions={{
+    meta: {
+      select: ["firstName", "lastName", "fullName"]
+    }
+  }}
+  fullWidth
+  sort={{ field: "lastName", order: "ASC" }}
+  perPage={0}
+>
+  <AutocompleteInput
+    optionText="fullName"
+    filterToQuery={(q) => ({ q })}
+  />
+</ReferenceInput>
+```
+
+### Expand fields
+
+If an entity has nested fields, you can ask the API to include them in the response.
+
+```ts
+<ReferenceInput
+  source="company.id"
+  reference="companies"
+  queryOptions={{
+    meta: {
+      expand: ["city", "city.info", "city.info.company"]
+    }
+  }}
+  fullWidth
+  sort={{ field: "name", order: "ASC" }}
+  perPage={0}
+>
+  <AutocompleteInput
+    optionText="name"
+    filterToQuery={(q) => ({ q })}
+  />
+</ReferenceInput>
+```
+
 ### OData Actions
 
 This provider has built-in support for invoking OData actions. This works with react-admin's

--- a/src/ArrayFilterExpressions/ArrayFilterExpressions.test.ts
+++ b/src/ArrayFilterExpressions/ArrayFilterExpressions.test.ts
@@ -1,4 +1,4 @@
-import ArrayFilterExpressions from './ArrayFilterExpressions';
+import ArrayFilterExpressions from "./ArrayFilterExpressions";
 
 let arrayFilterExpressions: ArrayFilterExpressions;
 

--- a/src/ArrayFilterExpressions/ArrayFilterExpressions.test.ts
+++ b/src/ArrayFilterExpressions/ArrayFilterExpressions.test.ts
@@ -1,0 +1,35 @@
+import ArrayFilterExpressions from './ArrayFilterExpressions';
+
+let arrayFilterExpressions: ArrayFilterExpressions;
+
+describe('executors/FilterExecutor/ArrayFilterExpressions', () => {
+  beforeEach(() => {
+    arrayFilterExpressions = new ArrayFilterExpressions();
+  });
+
+  test('should add expression to filters array', () => {
+    arrayFilterExpressions.add('Field eq 1');
+    arrayFilterExpressions.add('Field eq 2');
+
+    expect(arrayFilterExpressions.toString()).toEqual('Field eq 1 and Field eq 2');
+  });
+
+  test('should filter duplicates in result', () => {
+    arrayFilterExpressions.add('Field eq 1');
+    arrayFilterExpressions.add('Field eq 1');
+
+    expect(arrayFilterExpressions.toString()).toEqual('Field eq 1');
+  });
+
+  test('should clear filters array', () => {
+    arrayFilterExpressions.add('Field eq 1');
+    arrayFilterExpressions.add('Field eq 1');
+    arrayFilterExpressions.clear();
+
+    expect(arrayFilterExpressions.toString()).toEqual('');
+  });
+
+  test('should thrown error if call with empty filter expression', () => {
+    expect(() => arrayFilterExpressions.add("")).toThrow(Error);
+  });
+});

--- a/src/ArrayFilterExpressions/ArrayFilterExpressions.ts
+++ b/src/ArrayFilterExpressions/ArrayFilterExpressions.ts
@@ -1,0 +1,27 @@
+export default class ArrayFilterExpressions {
+  private filterExpressions!: Set<string>;
+
+  constructor() {
+    this.filterExpressions = new Set<string>();
+  }
+
+  public add(filterExpression: string): ArrayFilterExpressions {
+    if (filterExpression.length === 0) {
+      throw new Error("Filter expression can't be empty");
+    }
+
+    this.filterExpressions.add(filterExpression);
+
+    return this;
+  }
+
+  public clear(): ArrayFilterExpressions {
+    this.filterExpressions.clear();
+
+    return this;
+  }
+
+  public toString(): string {
+    return Array.from(this.filterExpressions).join(' and ');
+  }
+}

--- a/src/ArrayFilterExpressions/index.ts
+++ b/src/ArrayFilterExpressions/index.ts
@@ -1,0 +1,1 @@
+export { default as ArrayFilterExpressions } from './ArrayFilterExpressions';

--- a/src/ArrayFilterExpressions/index.ts
+++ b/src/ArrayFilterExpressions/index.ts
@@ -1,1 +1,1 @@
-export { default as ArrayFilterExpressions } from './ArrayFilterExpressions';
+export { default as ArrayFilterExpressions } from "./ArrayFilterExpressions";

--- a/src/create.test.ts
+++ b/src/create.test.ts
@@ -1,5 +1,5 @@
-import odataProvider from "./index";
 import fetchMock from "jest-fetch-mock";
+import odataProvider from "./index";
 
 fetchMock.dontMock();
 

--- a/src/expand.test.ts
+++ b/src/expand.test.ts
@@ -1,0 +1,60 @@
+import * as fs from "fs";
+import { enableFetchMocks } from "jest-fetch-mock";
+import odataProvider from "./index";
+
+enableFetchMocks();
+
+const Northwind = "https://services.odata.org/v4/Northwind/Northwind.svc";
+const ODataSample = "https://services.odata.org/v4/OData/OData.svc";
+const nw_metadata = fs
+  .readFileSync("./test/metadata/Northwind.metadata.xml")
+  .toString();
+
+const sample_metadata = fs
+  .readFileSync("./test/metadata/OData.metadata.xml")
+  .toString();
+
+//
+// Setup mock fetch data
+//
+beforeEach(() => {
+  fetchMock.resetMocks();
+  fetchMock.doMock();
+  fetchMock.mockResponse((req) => {
+    if (req.url.startsWith(Northwind)) {
+      if (req.url.endsWith("/$metadata")) {
+        return Promise.resolve(nw_metadata);
+      }
+    }
+    if (req.url.startsWith(ODataSample)) {
+      if (req.url.endsWith("/$metadata")) {
+        return Promise.resolve(sample_metadata);
+      }
+    }
+    return Promise.resolve("");
+  });
+});
+
+//
+// Jest test to verify the "country.name" sort field name
+//
+test('expand fields ["company", "city", "city.info", "city.info.company"]', async () => {
+  const provider = await odataProvider(Northwind);
+  fetchMock.mockOnce(
+    fs.readFileSync("./test/service/Customers.json").toString(),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  await provider.getList("Customers", {
+    pagination: { page: 1, perPage: 15 },
+    sort: { field: "country.name", order: "asc" },
+    filter: {},
+    meta: {
+      expand: ["company", "city", "city.info", "city.info.company"],
+    }
+  });
+  expect(fetchMock.mock.calls[1][0]).toEqual(
+    Northwind +
+      "/Customers?$orderby=Country/Name asc&$top=15&$expand=Company,City,City($expand=Info),City($expand=Info($expand=Company))&$count=true"
+  );
+  expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+});

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -1,7 +1,7 @@
-import fs from "fs";
-import odataProvider from "./index";
+import * as fs from "fs";
 import { enableFetchMocks } from "jest-fetch-mock";
-import { ODataNewOptions } from "@odata/client";
+import odataProvider from "./index";
+
 enableFetchMocks();
 
 const Northwind = "https://services.odata.org/v4/Northwind/Northwind.svc";
@@ -44,7 +44,7 @@ test("filter q", async () => {
     fs.readFileSync("./test/service/Customers.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Customers", {
+  await provider.getList("Customers", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ContactName", order: "asc" },
     filter: { q: "Search string" },
@@ -65,7 +65,7 @@ test("filter_q", async () => {
     fs.readFileSync("./test/service/Customers.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Customers", {
+  await provider.getList("Customers", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ContactName", order: "asc" },
     filter: { ContactName_q: "Alejandra" },
@@ -86,7 +86,7 @@ test("filter_neq", async () => {
     fs.readFileSync("./test/service/Customers.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Customers", {
+  await provider.getList("Customers", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ContactName", order: "asc" },
     filter: { ContactName_neq: "Alejandra Camino" },
@@ -107,7 +107,7 @@ test("filter_eq", async () => {
     fs.readFileSync("./test/service/Customers.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Customers", {
+  await provider.getList("Customers", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ContactName", order: "asc" },
     filter: { ContactName_eq: "Alejandra Camino" },
@@ -128,7 +128,7 @@ test("filter_lte", async () => {
     fs.readFileSync("./test/service/Products.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Products", {
+  await provider.getList("Products", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ProductID", order: "asc" },
     filter: { UnitPrice_lte: 10 },
@@ -149,7 +149,7 @@ test("filter_lt", async () => {
     fs.readFileSync("./test/service/Products.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Products", {
+  await provider.getList("Products", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ProductID", order: "asc" },
     filter: { UnitPrice_lt: 10 },
@@ -170,7 +170,7 @@ test("filter_gte", async () => {
     fs.readFileSync("./test/service/Products.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Products", {
+  await provider.getList("Products", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ProductID", order: "asc" },
     filter: { UnitPrice_gte: 10 },
@@ -191,7 +191,7 @@ test("filter_gt", async () => {
     fs.readFileSync("./test/service/Products.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Products", {
+  await provider.getList("Products", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ProductID", order: "asc" },
     filter: { UnitPrice_gt: 10 },
@@ -212,7 +212,7 @@ test("filter_eq_any", async () => {
     fs.readFileSync("./test/service/Products.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Products", {
+  await provider.getList("Products", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ProductID", order: "asc" },
     filter: { UnitPrice_eq_any: [10, 20], UnitPrice2_eq_any: [10, 20] },
@@ -233,7 +233,7 @@ test("filter_neq_any", async () => {
     fs.readFileSync("./test/service/Products.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Products", {
+  await provider.getList("Products", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ProductID", order: "asc" },
     filter: { UnitPrice_neq_any: [10, 20] },
@@ -254,7 +254,7 @@ test("filter_boolean", async () => {
     fs.readFileSync("./test/service/Customers.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Customers", {
+  await provider.getList("Customers", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ContactName", order: "asc" },
     filter: { ContactName_boolean: true },
@@ -275,7 +275,7 @@ test("filter_inc", async () => {
     fs.readFileSync("./test/service/Products.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Products", {
+  await provider.getList("Products", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ProductID", order: "asc" },
     filter: { UnitPrice_inc: [10, '20'] },
@@ -296,7 +296,7 @@ test("filter_inc_any", async () => {
     fs.readFileSync("./test/service/Products.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Products", {
+  await provider.getList("Products", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ProductID", order: "asc" },
     filter: { UnitPrice_inc_any: [10, '20'] },
@@ -317,7 +317,7 @@ test("filter_ninc_any", async () => {
     fs.readFileSync("./test/service/Products.json").toString(),
     { headers: { "Content-Type": "application/json" } }
   );
-  const { data, total } = await provider.getList("Products", {
+  await provider.getList("Products", {
     pagination: { page: 1, perPage: 15 },
     sort: { field: "ProductID", order: "asc" },
     filter: { UnitPrice_ninc_any: [10, '20'] },

--- a/src/filter.test.ts
+++ b/src/filter.test.ts
@@ -36,6 +36,48 @@ beforeEach(() => {
 });
 
 //
+// Jest test to verify the q filter field name
+//
+test("filter q", async () => {
+  const provider = await odataProvider(Northwind);
+  fetchMock.mockOnce(
+    fs.readFileSync("./test/service/Customers.json").toString(),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  const { data, total } = await provider.getList("Customers", {
+    pagination: { page: 1, perPage: 15 },
+    sort: { field: "ContactName", order: "asc" },
+    filter: { q: "Search string" },
+  });
+  expect(fetchMock.mock.calls[1][0]).toEqual(
+    Northwind +
+      "/Customers?$orderby=ContactName asc&$top=15&$count=true&$search=Search string"
+  );
+  expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+});
+
+//
+// Jest test to verify the _q filter functionality
+//
+test("filter_q", async () => {
+  const provider = await odataProvider(Northwind);
+  fetchMock.mockOnce(
+    fs.readFileSync("./test/service/Customers.json").toString(),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  const { data, total } = await provider.getList("Customers", {
+    pagination: { page: 1, perPage: 15 },
+    sort: { field: "ContactName", order: "asc" },
+    filter: { ContactName_q: "Alejandra" },
+  });
+  expect(fetchMock.mock.calls[1][0]).toEqual(
+    Northwind +
+      "/Customers?$filter=Contains(ContactName,'Alejandra') eq true&$orderby=ContactName asc&$top=15&$count=true"
+  );
+  expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+});
+
+//
 // Jest test to verify the _neq filter functionality
 //
 test("filter_neq", async () => {
@@ -101,7 +143,7 @@ test("filter_lte", async () => {
 //
 // Jest test to verify the _lt filter functionality
 //
-test("filter_lte", async () => {
+test("filter_lt", async () => {
   const provider = await odataProvider(Northwind);
   fetchMock.mockOnce(
     fs.readFileSync("./test/service/Products.json").toString(),
@@ -143,7 +185,7 @@ test("filter_gte", async () => {
 //
 // Jest test to verify the _gt filter functionality
 //
-test("filter_gte", async () => {
+test("filter_gt", async () => {
   const provider = await odataProvider(Northwind);
   fetchMock.mockOnce(
     fs.readFileSync("./test/service/Products.json").toString(),
@@ -157,6 +199,132 @@ test("filter_gte", async () => {
   expect(fetchMock.mock.calls[1][0]).toEqual(
     Northwind +
       "/Products?$filter=UnitPrice gt 10&$orderby=ProductID asc&$top=15&$count=true"
+  );
+  expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+});
+
+//
+// Jest test to verify the _eq_any filter functionality
+//
+test("filter_eq_any", async () => {
+  const provider = await odataProvider(Northwind);
+  fetchMock.mockOnce(
+    fs.readFileSync("./test/service/Products.json").toString(),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  const { data, total } = await provider.getList("Products", {
+    pagination: { page: 1, perPage: 15 },
+    sort: { field: "ProductID", order: "asc" },
+    filter: { UnitPrice_eq_any: [10, 20], UnitPrice2_eq_any: [10, 20] },
+  });
+  expect(fetchMock.mock.calls[1][0]).toEqual(
+    Northwind +
+      "/Products?$filter=(UnitPrice eq 10 or UnitPrice eq 20) and (UnitPrice2 eq 10 or UnitPrice2 eq 20)&$orderby=ProductID asc&$top=15&$count=true"
+  );
+  expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+});
+
+//
+// Jest test to verify the _neq_any filter functionality
+//
+test("filter_neq_any", async () => {
+  const provider = await odataProvider(Northwind);
+  fetchMock.mockOnce(
+    fs.readFileSync("./test/service/Products.json").toString(),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  const { data, total } = await provider.getList("Products", {
+    pagination: { page: 1, perPage: 15 },
+    sort: { field: "ProductID", order: "asc" },
+    filter: { UnitPrice_neq_any: [10, 20] },
+  });
+  expect(fetchMock.mock.calls[1][0]).toEqual(
+    Northwind +
+      "/Products?$filter=(UnitPrice eq 10 or UnitPrice eq 20) eq false&$orderby=ProductID asc&$top=15&$count=true"
+  );
+  expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+});
+
+//
+// Jest test to verify the _eq filter functionality
+//
+test("filter_boolean", async () => {
+  const provider = await odataProvider(Northwind);
+  fetchMock.mockOnce(
+    fs.readFileSync("./test/service/Customers.json").toString(),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  const { data, total } = await provider.getList("Customers", {
+    pagination: { page: 1, perPage: 15 },
+    sort: { field: "ContactName", order: "asc" },
+    filter: { ContactName_boolean: true },
+  });
+  expect(fetchMock.mock.calls[1][0]).toEqual(
+    Northwind +
+      "/Customers?$filter=ContactName eq true&$orderby=ContactName asc&$top=15&$count=true"
+  );
+  expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+});
+
+//
+// Jest test to verify the _inc filter functionality
+//
+test("filter_inc", async () => {
+  const provider = await odataProvider(Northwind);
+  fetchMock.mockOnce(
+    fs.readFileSync("./test/service/Products.json").toString(),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  const { data, total } = await provider.getList("Products", {
+    pagination: { page: 1, perPage: 15 },
+    sort: { field: "ProductID", order: "asc" },
+    filter: { UnitPrice_inc: [10, '20'] },
+  });
+  expect(fetchMock.mock.calls[1][0]).toEqual(
+    Northwind +
+      "/Products?$filter=(UnitPrice eq 10) and (UnitPrice eq '20')&$orderby=ProductID asc&$top=15&$count=true"
+  );
+  expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+});
+
+//
+// Jest test to verify the _inc_any filter functionality
+//
+test("filter_inc_any", async () => {
+  const provider = await odataProvider(Northwind);
+  fetchMock.mockOnce(
+    fs.readFileSync("./test/service/Products.json").toString(),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  const { data, total } = await provider.getList("Products", {
+    pagination: { page: 1, perPage: 15 },
+    sort: { field: "ProductID", order: "asc" },
+    filter: { UnitPrice_inc_any: [10, '20'] },
+  });
+  expect(fetchMock.mock.calls[1][0]).toEqual(
+    Northwind +
+      "/Products?$filter=(UnitPrice eq 10) or (UnitPrice eq '20')&$orderby=ProductID asc&$top=15&$count=true"
+  );
+  expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+});
+
+//
+// Jest test to verify the _ninc_any filter functionality
+//
+test("filter_ninc_any", async () => {
+  const provider = await odataProvider(Northwind);
+  fetchMock.mockOnce(
+    fs.readFileSync("./test/service/Products.json").toString(),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  const { data, total } = await provider.getList("Products", {
+    pagination: { page: 1, perPage: 15 },
+    sort: { field: "ProductID", order: "asc" },
+    filter: { UnitPrice_ninc_any: [10, '20'] },
+  });
+  expect(fetchMock.mock.calls[1][0]).toEqual(
+    Northwind +
+      "/Products?$filter=(UnitPrice ne 10) and (UnitPrice ne '20')&$orderby=ProductID asc&$top=15&$count=true"
   );
   expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
 });

--- a/src/filterNameParser/filterNameParser.test.ts
+++ b/src/filterNameParser/filterNameParser.test.ts
@@ -1,0 +1,28 @@
+import {
+  filterNameParser,
+  operators,
+} from "./filterNameParser";
+
+test("Thrown error if filter name doesn't contain an operator", () => {
+  expect(() => filterNameParser("filterName")).toThrow(Error);
+});
+
+operators.forEach((operator) => {
+  test(`Parse filterName_${operator}`, () => {
+    const {
+      fieldName: parsedFieldName,
+      operator: parsedOperator,
+    } = filterNameParser(`filterName_${operator}`);
+    expect(parsedFieldName).toEqual("FilterName");
+    expect(parsedOperator).toEqual(operator);
+  });
+
+  test(`Parse filter.name_${operator}`, () => {
+    const {
+      fieldName: parsedFieldName,
+      operator: parsedOperator,
+    } = filterNameParser(`filter.name_${operator}`);
+    expect(parsedFieldName).toEqual("Filter/Name");
+    expect(parsedOperator).toEqual(operator);
+  });
+});

--- a/src/filterNameParser/filterNameParser.ts
+++ b/src/filterNameParser/filterNameParser.ts
@@ -1,3 +1,5 @@
+import { getODataLikeKeyFormat } from "../helpers";
+
 export type Operator =
 "q"
 | "neq"
@@ -32,37 +34,6 @@ export const operators: Operator[] = [
 export interface FilterNameParserResult {
   fieldName: string;
   operator: Operator;
-}
-
-/**
- * Capitalizes the first letter of the input string.
- *
- * @example
- * const fieldName = capitalize("city");
- * console.log(fieldName); // City
- *
- * @param {string} fieldName - the input string to be capitalized
- * @return {string} the capitalized string
- */
-function capitalize(fieldName: string): string {
-  return `${fieldName.charAt(0).toUpperCase()}${fieldName.slice(1)}`;
-}
-
-/**
- * Returns a string in OData-like key format.
- *
- * @example
- * const fieldName = capitalize("city.name");
- * console.log(fieldName); // City/Name
- *
- * @param {string} fieldName - the field name to be formatted
- * @return {string} the formatted OData-like key
- */
-export function getODataLikeKeyFormat(fieldName: string): string {
-  return fieldName
-    .split('.')
-    .map(capitalize)
-    .join('/');
 }
 
 /**

--- a/src/filterNameParser/filterNameParser.ts
+++ b/src/filterNameParser/filterNameParser.ts
@@ -1,0 +1,105 @@
+export type Operator =
+"q"
+| "neq"
+| "eq"
+| "lte"
+| "lt"
+| "gte"
+| "gt"
+| "eq_any"
+| "neq_any"
+| "boolean"
+| "inc"
+| "inc_any"
+| "ninc_any";
+
+export const operators: Operator[] = [
+  "q",
+  "neq",
+  "eq",
+  "lte",
+  "lt",
+  "gte",
+  "gt",
+  "eq_any",
+  "neq_any",
+  "boolean",
+  "inc",
+  "inc_any",
+  "ninc_any",
+];
+
+export interface FilterNameParserResult {
+  fieldName: string;
+  operator: Operator;
+}
+
+/**
+ * Capitalizes the first letter of the input string.
+ *
+ * @example
+ * const fieldName = capitalize("city");
+ * console.log(fieldName); // City
+ *
+ * @param {string} fieldName - the input string to be capitalized
+ * @return {string} the capitalized string
+ */
+function capitalize(fieldName: string): string {
+  return `${fieldName.charAt(0).toUpperCase()}${fieldName.slice(1)}`;
+}
+
+/**
+ * Returns a string in OData-like key format.
+ *
+ * @example
+ * const fieldName = capitalize("city.name");
+ * console.log(fieldName); // City/Name
+ *
+ * @param {string} fieldName - the field name to be formatted
+ * @return {string} the formatted OData-like key
+ */
+export function getODataLikeKeyFormat(fieldName: string): string {
+  return fieldName
+    .split('.')
+    .map(capitalize)
+    .join('/');
+}
+
+/**
+ * Parses the filter name to extract the field name and operator.
+ *
+ * @example
+ * const { fieldName, operator } = filterNameParser("city.name_eq");
+ * console.log(fieldName); // CityName
+ * console.log(operator); // eq
+ *
+ * @param {string} filterName - the filter name to parse
+ * @return {FilterNameParserResult} an object containing the parsed fieldName and operator
+ */
+export function filterNameParser(filterName: string): FilterNameParserResult {
+  const containsOperator = operators.some((operator) => filterName.endsWith(operator));
+
+  if (!containsOperator) {
+    throw new Error(`Field name "${filterName}" must contain an operator: ${operators.join(", ")}`);
+  }
+
+  let fieldName: string | null = null;
+  let operator: Operator | null = null;
+
+  for (let i = 0; i < operators.length; i++) {
+    if (filterName.endsWith(`_${operators[i]}`)) {
+      fieldName = filterName.replace(`_${operators[i]}`, "");
+      operator = operators[i];
+      break;
+    }
+  }
+
+  if (fieldName === null || operator === null) {
+    throw new Error("fieldName and operator must be required");
+  }
+
+  return {
+    fieldName: getODataLikeKeyFormat(fieldName),
+    operator,
+  };
+}

--- a/src/filterNameParser/index.ts
+++ b/src/filterNameParser/index.ts
@@ -1,0 +1,1 @@
+export * from './filterNameParser';

--- a/src/helpers/capitalize.ts
+++ b/src/helpers/capitalize.ts
@@ -1,0 +1,13 @@
+/**
+ * Capitalizes the first letter of the input string.
+ *
+ * @example
+* const fieldName = capitalize("city");
+* console.log(fieldName); // City
+*
+* @param {string} fieldName - the input string to be capitalized
+* @return {string} the capitalized string
+*/
+export function capitalize(fieldName: string): string {
+ return `${fieldName.charAt(0).toUpperCase()}${fieldName.slice(1)}`;
+}

--- a/src/helpers/getExpandString.ts
+++ b/src/helpers/getExpandString.ts
@@ -1,0 +1,33 @@
+import { getODataLikeKeyFormat } from "./getODataLikeKeyFormat";
+
+/**
+ * @example
+ * import { getExpandString } from "./helpers";
+ *
+ * getExpandString(['company', 'city', 'city.info']); // $expand=Company,City,City($expand=Info)
+ */
+export function getExpandString(key: string): string {
+  const odataKey = getODataLikeKeyFormat(key);
+  const keyAsArrayOfReversedString = odataKey.split('/').reverse();
+
+  if (keyAsArrayOfReversedString.length === 1) {
+    return odataKey;
+  }
+
+  let result = '';
+
+  for (let i = 0; i <= keyAsArrayOfReversedString.length; i += 1) {
+    const child: string = keyAsArrayOfReversedString[i];
+    const parent: string | undefined = keyAsArrayOfReversedString[i + 1];
+
+    if (!parent) {
+      return result;
+    }
+
+    result = result === ''
+      ? `${parent}($expand=${child})`
+      : `${parent}($expand=${result})`;
+  }
+
+  return result;
+}

--- a/src/helpers/getODataLikeKeyFormat.ts
+++ b/src/helpers/getODataLikeKeyFormat.ts
@@ -1,0 +1,30 @@
+/**
+ * Capitalizes the first letter of the input string.
+ *
+ * @example
+* const fieldName = capitalize("city");
+* console.log(fieldName); // City
+*
+* @param {string} fieldName - the input string to be capitalized
+* @return {string} the capitalized string
+*/
+function capitalize(fieldName: string): string {
+ return `${fieldName.charAt(0).toUpperCase()}${fieldName.slice(1)}`;
+}
+
+/**
+* Returns a string in OData-like key format.
+*
+* @example
+* const fieldName = capitalize("city.name");
+* console.log(fieldName); // City/Name
+*
+* @param {string} fieldName - the field name to be formatted
+* @return {string} the formatted OData-like key
+*/
+export function getODataLikeKeyFormat(fieldName: string): string {
+ return fieldName
+   .split('.')
+   .map(capitalize)
+   .join('/');
+}

--- a/src/helpers/getODataLikeKeyFormat.ts
+++ b/src/helpers/getODataLikeKeyFormat.ts
@@ -1,16 +1,4 @@
-/**
- * Capitalizes the first letter of the input string.
- *
- * @example
-* const fieldName = capitalize("city");
-* console.log(fieldName); // City
-*
-* @param {string} fieldName - the input string to be capitalized
-* @return {string} the capitalized string
-*/
-function capitalize(fieldName: string): string {
- return `${fieldName.charAt(0).toUpperCase()}${fieldName.slice(1)}`;
-}
+import { capitalize } from "./capitalize";
 
 /**
 * Returns a string in OData-like key format.

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,1 +1,3 @@
-export * from "./getODataLikeKeyFormat";
+export * from './capitalize';
+export * from './getExpandString';
+export * from './getODataLikeKeyFormat';

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export * from "./getODataLikeKeyFormat";

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,8 +21,9 @@ import {
 } from "@odata/client";
 import { resource_id_mapper } from "./ra-data-id-mapper";
 import { parse_metadata } from "./metadata_parser";
-import { ArrayFilterExpressions } from './ArrayFilterExpressions';
-import { filterNameParser } from './filterNameParser';
+import { ArrayFilterExpressions } from "./ArrayFilterExpressions";
+import { filterNameParser } from "./filterNameParser";
+import { getODataLikeKeyFormat } from "./helpers";
 
 async function get_entities(
   url: string,
@@ -149,7 +150,7 @@ const ra_data_odata_server = async (
 
         const queryOptions = new SystemQueryOptions()
           .count()
-          .orderby(field, order === "DESC" ? "desc" : "asc")
+          .orderby(getODataLikeKeyFormat(field), order === "DESC" ? "desc" : "asc")
           .skip((page - 1) * perPage)
           .top(perPage);
 
@@ -327,7 +328,7 @@ const ra_data_odata_server = async (
                 .property(params.target)
                 .eq(getproperty_identifier(resource, params.target, params.id))
             )
-            .orderby(field, order === "DESC" ? "desc" : "asc")
+            .orderby(getODataLikeKeyFormat(field), order === "DESC" ? "desc" : "asc")
             .skip((page - 1) * perPage)
             .top(perPage);
           return await getEntities<RecordType>(resource, odataParams);

--- a/src/init.test.ts
+++ b/src/init.test.ts
@@ -1,7 +1,8 @@
-import fs from "fs";
-import odataProvider from "./index";
+import * as fs from "fs";
 import { enableFetchMocks } from "jest-fetch-mock";
 import { ODataNewOptions } from "@odata/client";
+import odataProvider from "./index";
+
 enableFetchMocks();
 
 const Northwind = "https://services.odata.org/v4/Northwind/Northwind.svc";

--- a/src/metadata.test.ts
+++ b/src/metadata.test.ts
@@ -1,5 +1,5 @@
+import * as fs from "fs";
 import { EntityProperty, parse_metadata } from "./metadata_parser";
-import fs from "fs";
 
 const nw = fs.readFileSync("./test/metadata/Northwind.metadata.xml").toString();
 

--- a/src/select.test.ts
+++ b/src/select.test.ts
@@ -1,0 +1,60 @@
+import * as fs from "fs";
+import { enableFetchMocks } from "jest-fetch-mock";
+import odataProvider from "./index";
+
+enableFetchMocks();
+
+const Northwind = "https://services.odata.org/v4/Northwind/Northwind.svc";
+const ODataSample = "https://services.odata.org/v4/OData/OData.svc";
+const nw_metadata = fs
+  .readFileSync("./test/metadata/Northwind.metadata.xml")
+  .toString();
+
+const sample_metadata = fs
+  .readFileSync("./test/metadata/OData.metadata.xml")
+  .toString();
+
+//
+// Setup mock fetch data
+//
+beforeEach(() => {
+  fetchMock.resetMocks();
+  fetchMock.doMock();
+  fetchMock.mockResponse((req) => {
+    if (req.url.startsWith(Northwind)) {
+      if (req.url.endsWith("/$metadata")) {
+        return Promise.resolve(nw_metadata);
+      }
+    }
+    if (req.url.startsWith(ODataSample)) {
+      if (req.url.endsWith("/$metadata")) {
+        return Promise.resolve(sample_metadata);
+      }
+    }
+    return Promise.resolve("");
+  });
+});
+
+//
+// Jest test to verify the "country.name" sort field name
+//
+test('select only fields ["name", "country"]', async () => {
+  const provider = await odataProvider(Northwind);
+  fetchMock.mockOnce(
+    fs.readFileSync("./test/service/Customers.json").toString(),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  await provider.getList("Customers", {
+    pagination: { page: 1, perPage: 15 },
+    sort: { field: "country.name", order: "asc" },
+    filter: {},
+    meta: {
+      select: ["name", "country"],
+    }
+  });
+  expect(fetchMock.mock.calls[1][0]).toEqual(
+    Northwind +
+      "/Customers?$orderby=Country/Name asc&$select=Name,Country&$top=15&$count=true"
+  );
+  expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+});

--- a/src/sort.test.ts
+++ b/src/sort.test.ts
@@ -1,0 +1,57 @@
+import * as fs from "fs";
+import { enableFetchMocks } from "jest-fetch-mock";
+import odataProvider from "./index";
+
+enableFetchMocks();
+
+const Northwind = "https://services.odata.org/v4/Northwind/Northwind.svc";
+const ODataSample = "https://services.odata.org/v4/OData/OData.svc";
+const nw_metadata = fs
+  .readFileSync("./test/metadata/Northwind.metadata.xml")
+  .toString();
+
+const sample_metadata = fs
+  .readFileSync("./test/metadata/OData.metadata.xml")
+  .toString();
+
+//
+// Setup mock fetch data
+//
+beforeEach(() => {
+  fetchMock.resetMocks();
+  fetchMock.doMock();
+  fetchMock.mockResponse((req) => {
+    if (req.url.startsWith(Northwind)) {
+      if (req.url.endsWith("/$metadata")) {
+        return Promise.resolve(nw_metadata);
+      }
+    }
+    if (req.url.startsWith(ODataSample)) {
+      if (req.url.endsWith("/$metadata")) {
+        return Promise.resolve(sample_metadata);
+      }
+    }
+    return Promise.resolve("");
+  });
+});
+
+//
+// Jest test to verify the "country.name" sort field name
+//
+test('sort by "country.name" field', async () => {
+  const provider = await odataProvider(Northwind);
+  fetchMock.mockOnce(
+    fs.readFileSync("./test/service/Customers.json").toString(),
+    { headers: { "Content-Type": "application/json" } }
+  );
+  await provider.getList("Customers", {
+    pagination: { page: 1, perPage: 15 },
+    sort: { field: "country.name", order: "asc" },
+    filter: {},
+  });
+  expect(fetchMock.mock.calls[1][0]).toEqual(
+    Northwind +
+      "/Customers?$orderby=Country/Name asc&$top=15&$count=true"
+  );
+  expect(fetchMock.mock.calls[1][1]?.method).toEqual("GET");
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "dist"
+  },
+  "exclude": [
+    "**/*.test.*"
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,7 @@
   "extends": "@tsconfig/node10/tsconfig.json",
   "compilerOptions": {
     "lib": ["DOM", "ES2018"],
-    "declaration": true,
-    "declarationMap": true,
-    "allowJs": false,
-    "outDir": "dist"
+    "allowJs": false
   },
   "include": ["src"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
1. Added support for all filter operators provided by the [ra-form-layout](https://marmelab.com/ra-enterprise/modules/ra-form-layout#filters-configuration) package.
2. If the filter name is `q`, then the value is used as the [search query](https://www.odata.org/getting-started/basic-tutorial/#search) ($search=Value).
3. I changed the build configuration so that the tests do not end up in the dist folder.
4. Add sort field transform to OData like format. For example, `{ sort: { field: "category.name", order: "asc" } }` will turn into `$orderby=Country/Name asc`.
5. Add select transformers. For example, `{ meta: { select: ["category", "city"] } }` will turn into `$select=Category,City`.
6. Add expand transformers. For example, `{ meta: { expand: ["company", "city", "city.info", "city.info.company"] } }` will turn into `$expand=Company,City,City($expand=Info),City($expand=Info($expand=Company))`.